### PR TITLE
Use `sha256` instead of `sha1`

### DIFF
--- a/arcanist.rb
+++ b/arcanist.rb
@@ -3,11 +3,11 @@ require "formula"
 class Arcanist < Formula
   resource "libphutil" do
     url "https://github.com/facebook/libphutil.git"
-    sha1 ""
+    sha256 ""
   end
   homepage "https://github.com/facebook/arcanist"
   head "git://github.com/facebook/arcanist.git"
-  sha1 ""
+  sha256 ""
   version "1"
   def install
     system "cp", "-r", ".", prefix


### PR DESCRIPTION
I got this error whilst attempting to use your formula:

```
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/ryfow/homebrew-phabricator/arcanist.rb
Calling Resource#sha1 is disabled!
Use Resource#sha256 instead.
```

So, I followed the instructions. Thanks!